### PR TITLE
Declare new bin `cli-less2css`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,6 +23,7 @@
         "bin/cli-copy",
         "bin/cli-minify",
         "bin/cli-sass2css",
+        "bin/cli-less2css",
         "bin/cli-revision"
     ],
     "scripts": {


### PR DESCRIPTION
The declaration is necessary for the script to be copied to
`vendor/bin`.

	modified:   composer.json