### PR TITLE
Fix `require-dev`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
       "PhpCliTools\\": "src/lib/"
     }
   },
-  "require-dev": {
+  "require": {
     "scssphp/scssphp": "1.0.4",
     "leafo/lessphp": "dev-master"
   },


### PR DESCRIPTION
The `require-dev` attribute also works on root-only composer.json so we have to replace it with a `require`.

	modified:   composer.json